### PR TITLE
Change example from SHA-256 to sha256

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ const salt = 'strongly-encouraged';
 // optional parameter
 const info = 'optional-context';
 // HMAC hashing algorithm to use
-const hash = 'SHA-256';
+const hash = 'sha256';
 
 // Generic derivation
 //-------------------
@@ -157,7 +157,7 @@ HKDF expand action.
 | Param | Type | Description |
 | --- | --- | --- |
 | hash | <code>string</code> | Hash algorithm |
-| hash_len | <code>integer</code> | Hash digest length |
+| hash_len | <code>integer</code> | Hash digest length (can be derived used [hash_length](#hkdf.hash_length)) |
 | prk | <code>Buffer</code> \| <code>string</code> | A buffer with pseudorandom key |
 | length | <code>integer</code> | length of output keying material in octets |
 | info | <code>Buffer</code> \| <code>string</code> | Optional context (safe to skip) |


### PR DESCRIPTION
Just spinning up this module for the first time. Running `hkdf.hash_length` with `'SHA-256'` as in the examples and got this : 

```js
internal/crypto/hash.js:33
  this._handle = new _Hash(algorithm);
                 ^

Error: Digest method not supported
    at new Hash (internal/crypto/hash.js:33:18)
    at createHash (crypto.js:101:10)
    at Function.hash_length (/home/mix/projects/SSBC/private-box2/node_modules/futoin-hkdf/hkdf.js:54:19)
```

):

Looking at the source I see that SHA-256 isn't in your lookup, so it's falling down to `crypto.createHash` and something is breaking in there. I'm running Node.js v10.15.3

I think this change will help beginners more.