### PR TITLE
Use Buffer via module

### DIFF
--- a/hkdf.js
+++ b/hkdf.js
@@ -19,6 +19,7 @@
  * limitations under the License.
  */
 
+const { Buffer } = require( 'buffer' );
 const { createHash, createHmac } = require( 'crypto' );
 
 const g_digestLenCache = {};

--- a/hkdf.test-d.ts
+++ b/hkdf.test-d.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import { expectType } from "tsd";
 import hkdf = require(".");
 

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const { Suite } = require( 'benchmark' );
 const assert = require( 'assert' );
+const { Suite } = require( 'benchmark' );
+const { Buffer } = require( 'buffer' );
 
 const futoin_hkdf = require( '../hkdf' );
 

--- a/test/unittest.js
+++ b/test/unittest.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { Buffer } = require( 'buffer' );
 const crypto = require( 'crypto' );
 const hkdf = require( '../hkdf' );
 const tls = require( '../tls' );

--- a/tls.js
+++ b/tls.js
@@ -19,6 +19,7 @@
  * limitations under the License.
  */
 
+const { Buffer } = require( 'buffer' );
 const hkdf = require( './hkdf' );
 
 /**

--- a/tls.test-d.ts
+++ b/tls.test-d.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import { expectType } from "tsd";
 import hkdf_tls = require(".");
 


### PR DESCRIPTION
This change makes it easier to use hkdf in the browser, without needing to polyfill Buffer into a global. Node.JS has had a `buffer` module since at least 0.10.